### PR TITLE
fix: OAuth token handling - use HTTP-only cookies and remove token fr…

### DIFF
--- a/src/components/auth/OAuthCallback.tsx
+++ b/src/components/auth/OAuthCallback.tsx
@@ -26,6 +26,9 @@ export const OAuthCallback: React.FC = () => {
           // Token en URL (cross-site): usar el store global
           await loginWithGoogle(token);
           
+          // Limpiar token de URL por seguridad
+          window.history.replaceState({}, "", "/auth/callback");
+          
           navigate('/', { replace: true });
         } else {
           // Sin token en URL: verificar autenticación existente

--- a/src/stores/auth.store.ts
+++ b/src/stores/auth.store.ts
@@ -97,7 +97,6 @@ export const useAuthStore = create<AuthStore>()((set) => ({
         try {
             set({ isLoading: true, error: null });
             // Mark token as used to satisfy TS noUnusedParameters when running in cookie-based mode
-            void token;
 
             // Obtener perfil del usuario (las cookies HTTP-only se manejan automáticamente)
             const profileResponse = await apiService.getProfile();


### PR DESCRIPTION
…om URL

- Remove void token; from loginWithGoogle (auth.store.ts)
- Add window.history.replaceState to clear token from URL (OAuthCallback.tsx)
- Backend now uses HTTP-only cookies instead of token in URL
- Improved security and backward compatibility